### PR TITLE
Enable adding favorite places from the map UI

### DIFF
--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -58,6 +58,9 @@ main {
   border-radius: 0.75rem;
   padding: 1.5rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .place-details h3 {
@@ -68,6 +71,95 @@ main {
 
 .place-details p {
   margin-bottom: 0;
+}
+
+.divider {
+  border: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  margin: 0;
+}
+
+.form-section h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.form-description {
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.form-field input,
+.form-field textarea {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  color: inherit;
+  background-color: rgba(15, 23, 42, 0.6);
+}
+
+.form-field textarea {
+  resize: vertical;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  outline: 2px solid #38bdf8;
+  outline-offset: 1px;
+}
+
+.submit-button {
+  margin-top: 0.5rem;
+  background: linear-gradient(135deg, #22d3ee, #3b82f6);
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.35);
+}
+
+.submit-button:active {
+  transform: translateY(0);
+}
+
+.form-status {
+  min-height: 1.25rem;
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.form-status.success {
+  color: #34d399;
+}
+
+.form-status.error {
+  color: #f87171;
 }
 
 @media (max-width: 960px) {

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -11,6 +11,44 @@ document.addEventListener("DOMContentLoaded", async () => {
     maxZoom: 19,
   }).addTo(map);
 
+  const detailsElement = document.getElementById("place-details");
+  const form = document.getElementById("add-place-form");
+  const statusElement = document.getElementById("form-status");
+
+  const renderDetails = (place) => {
+    if (!detailsElement) return;
+
+    const { latitude, longitude } = place;
+    const latitudeText = Number.isFinite(latitude)
+      ? latitude.toFixed(4)
+      : String(latitude);
+    const longitudeText = Number.isFinite(longitude)
+      ? longitude.toFixed(4)
+      : String(longitude);
+
+    detailsElement.innerHTML = `
+      <div class="place-details">
+        <h3>${place.name}</h3>
+        <p>${place.description}</p>
+        <p class="coordinates">${latitudeText}, ${longitudeText}</p>
+      </div>
+    `;
+  };
+
+  const addMarkerForPlace = (place) => {
+    const marker = L.marker([place.latitude, place.longitude]).addTo(map);
+    marker.bindPopup(`
+      <h3>${place.name}</h3>
+      <p>${place.description}</p>
+    `);
+
+    marker.on("click", () => {
+      renderDetails(place);
+    });
+
+    return marker;
+  };
+
   try {
     const response = await fetch("/api/places");
     if (!response.ok) {
@@ -18,18 +56,79 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     const places = await response.json();
-    const detailsElement = document.getElementById("place-details");
-
-    places.forEach((place) => {
-      const marker = L.marker([place.latitude, place.longitude]).addTo(map);
-      marker.bindPopup(`\n        <h3>${place.name}</h3>\n        <p>${place.description}</p>\n      `);
-
-      marker.on("click", () => {
-        detailsElement.innerHTML = `\n          <div class="place-details">\n            <h3>${place.name}</h3>\n            <p>${place.description}</p>\n            <p class="coordinates">${place.latitude.toFixed(4)}, ${place.longitude.toFixed(4)}</p>\n          </div>\n        `;
-      });
-    });
+    places.forEach((place) => addMarkerForPlace(place));
   } catch (error) {
     console.error(error);
-    document.getElementById("place-details").innerHTML = `\n      <p role="alert">Unable to load favorite places right now. Please try again later.</p>\n    `;
+    if (detailsElement) {
+      detailsElement.innerHTML = `
+        <p role="alert">Unable to load favorite places right now. Please try again later.</p>
+      `;
+    }
   }
+
+  const setStatusMessage = (message, type = "") => {
+    if (!statusElement) return;
+    statusElement.textContent = message;
+    statusElement.classList.remove("success", "error");
+    if (type) {
+      statusElement.classList.add(type);
+    }
+  };
+
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const name = formData.get("name").toString().trim();
+    const description = formData.get("description").toString().trim();
+    const latitudeValue = formData.get("latitude").toString().trim();
+    const longitudeValue = formData.get("longitude").toString().trim();
+
+    if (!name || !description || !latitudeValue || !longitudeValue) {
+      setStatusMessage("Please fill out all fields before submitting.", "error");
+      return;
+    }
+
+    const latitude = Number.parseFloat(latitudeValue);
+    const longitude = Number.parseFloat(longitudeValue);
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      setStatusMessage("Latitude and longitude must be valid numbers.", "error");
+      return;
+    }
+
+    const payload = { name, description, latitude, longitude };
+
+    try {
+      setStatusMessage("Saving place...");
+
+      const response = await fetch("/api/places", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}));
+        const errorMessage = errorBody.error || "Unable to save the place.";
+        throw new Error(errorMessage);
+      }
+
+      const savedPlace = await response.json();
+      addMarkerForPlace(savedPlace).openPopup();
+      map.setView(
+        [savedPlace.latitude, savedPlace.longitude],
+        Math.max(map.getZoom(), 6)
+      );
+      renderDetails(savedPlace);
+      form.reset();
+      setStatusMessage(`Added '${savedPlace.name}' to your map!`, "success");
+    } catch (error) {
+      console.error(error);
+      setStatusMessage(
+        error instanceof Error ? error.message : "Unable to save the place.",
+        "error"
+      );
+    }
+  });
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -30,6 +30,64 @@
         <div id="place-details" class="place-details">
           <p>Select a pin on the map to read more about that location.</p>
         </div>
+
+        <div class="divider" role="presentation"></div>
+
+        <section class="form-section" aria-label="Add a new favorite place">
+          <h2>Add a favorite place</h2>
+          <p class="form-description">
+            Share a location you love by filling out the form below. The map will
+            update instantly with your new pin.
+          </p>
+          <form id="add-place-form" novalidate>
+            <div class="form-field">
+              <label for="place-name">Name</label>
+              <input
+                type="text"
+                id="place-name"
+                name="name"
+                placeholder="Location name"
+                required
+              />
+            </div>
+            <div class="form-field">
+              <label for="place-description">Description</label>
+              <textarea
+                id="place-description"
+                name="description"
+                rows="3"
+                placeholder="Why is this place special?"
+                required
+              ></textarea>
+            </div>
+            <div class="form-grid">
+              <div class="form-field">
+                <label for="place-latitude">Latitude</label>
+                <input
+                  type="text"
+                  id="place-latitude"
+                  name="latitude"
+                  inputmode="decimal"
+                  placeholder="e.g. 37.7749"
+                  required
+                />
+              </div>
+              <div class="form-field">
+                <label for="place-longitude">Longitude</label>
+                <input
+                  type="text"
+                  id="place-longitude"
+                  name="longitude"
+                  inputmode="decimal"
+                  placeholder="e.g. -122.4194"
+                  required
+                />
+              </div>
+            </div>
+            <button type="submit" class="submit-button">Add place</button>
+            <p id="form-status" class="form-status" role="status" aria-live="polite"></p>
+          </form>
+        </section>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- add an interactive form alongside the map so visitors can submit new favorite places
- style the form and status messaging to match the existing dark theme
- extend the Leaflet map script to post new places to the API and render markers immediately

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d83660a2c483248f2434ecf2236142